### PR TITLE
Add JSON import/export feature

### DIFF
--- a/app.js
+++ b/app.js
@@ -853,13 +853,58 @@
         // Delete client
         function deleteClient(clientId) {
             if (!confirm('Tem certeza que deseja excluir este cliente?')) return;
-            
+
             clients = clients.filter(client => client.id !== clientId);
             saveToStorage();
-            
+
             renderAdminClients();
             updateClientDropdown();
             alert('Cliente excluído com sucesso!');
+        }
+
+        // Export all data to a JSON file
+        function exportData() {
+            const data = { items, clients, orders };
+            const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'lavanderia_data.json';
+            link.click();
+            URL.revokeObjectURL(url);
+        }
+
+        // Import data from a JSON file
+        function importData(event) {
+            const file = event.target.files[0];
+            if (!file) return;
+
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                try {
+                    const data = JSON.parse(e.target.result);
+                    if (data.items && data.clients && data.orders) {
+                        items = data.items;
+                        clients = data.clients;
+                        orders = data.orders;
+                        quantities = {};
+                        items.forEach(it => { quantities[it.id] = 0; });
+                        saveToStorage();
+                        renderItems();
+                        renderAdminItems();
+                        renderAdminClients();
+                        renderHistory();
+                        updateClientDropdown();
+                        alert('Dados importados com sucesso!');
+                    } else {
+                        alert('Arquivo inválido.');
+                    }
+                } catch (err) {
+                    alert('Erro ao importar dados: ' + err.message);
+                }
+            };
+            reader.readAsText(file);
+            event.target.value = '';
         }
 
         // Initialize the app when page loads

--- a/index.html
+++ b/index.html
@@ -144,12 +144,12 @@
                 </div>
                 
                 <!-- Clients Admin -->
-                <div class="admin-section clients">
-                    <h3 class="section-title"><i class="fas fa-users"></i> Gestão de Clientes</h3>
-                    
-                    <div class="clients-list" id="admin-clients-list">
-                        <!-- Admin clients will be added here -->
-                    </div>
+                    <div class="admin-section clients">
+                        <h3 class="section-title"><i class="fas fa-users"></i> Gestão de Clientes</h3>
+
+                        <div class="clients-list" id="admin-clients-list">
+                            <!-- Admin clients will be added here -->
+                        </div>
                     
                     <div class="admin-form">
                         <h3 class="section-title"><i class="fas fa-user-plus"></i> Adicionar Novo Cliente</h3>
@@ -166,6 +166,20 @@
                             <input type="email" id="client-email" placeholder="Ex: cliente@exemplo.com">
                         </div>
                         <button class="save-btn" onclick="addNewClient()">Guardar Cliente</button>
+                    </div>
+                </div>
+
+                <!-- Import/Export Section -->
+                <div class="admin-section backup">
+                    <h3 class="section-title"><i class="fas fa-file-export"></i> Importar/Exportar Dados</h3>
+                    <div class="admin-form">
+                        <button class="save-btn" onclick="exportData()">
+                            <i class="fas fa-download"></i> Exportar Dados
+                        </button>
+                        <input type="file" id="import-file" accept="application/json" style="display:none" onchange="importData(event)">
+                        <button class="save-btn" onclick="document.getElementById('import-file').click()">
+                            <i class="fas fa-upload"></i> Importar Dados
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- allow admin users to export items, clients and orders
- allow importing a JSON backup
- add buttons in the admin tab for import/export

## Testing
- `python3 -m py_compile *.py`
- `node -c app.js`


------
https://chatgpt.com/codex/tasks/task_e_6853a1ecbcd0832794093492c628f064