### PR TITLE
Add import/export feature for order history

### DIFF
--- a/app.js
+++ b/app.js
@@ -853,13 +853,61 @@
         // Delete client
         function deleteClient(clientId) {
             if (!confirm('Tem certeza que deseja excluir este cliente?')) return;
-            
+
             clients = clients.filter(client => client.id !== clientId);
             saveToStorage();
-            
+
             renderAdminClients();
             updateClientDropdown();
             alert('Cliente excluído com sucesso!');
+        }
+
+        // Exportar histórico de pedidos para um ficheiro JSON
+        function exportOrders() {
+            if (orders.length === 0) {
+                alert('Nenhum pedido para exportar');
+                return;
+            }
+            const data = JSON.stringify(orders, null, 2);
+            const blob = new Blob([data], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'orders.json';
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        }
+
+        // Importar pedidos de um ficheiro JSON
+        function importOrders(event) {
+            const file = event.target.files[0];
+            if (!file) return;
+            const reader = new FileReader();
+            reader.onload = function(e) {
+                try {
+                    const data = JSON.parse(e.target.result);
+                    if (Array.isArray(data)) {
+                        data.forEach(o => {
+                            if (!orders.find(ex => ex.id === o.id)) {
+                                orders.push(o);
+                            }
+                        });
+                        orders.sort((a, b) => (b.timestamp || b.id) - (a.timestamp || a.id));
+                        saveToStorage();
+                        renderHistory();
+                        alert('Pedidos importados com sucesso!');
+                    } else {
+                        alert('Arquivo de importação inválido');
+                    }
+                } catch (err) {
+                    console.error('Erro ao importar', err);
+                    alert('Falha ao importar pedidos');
+                }
+            };
+            reader.readAsText(file);
+            event.target.value = '';
         }
 
         // Initialize the app when page loads

--- a/index.html
+++ b/index.html
@@ -106,7 +106,17 @@
                     <button class="filter-btn" data-filter="today">Hoje</button>
                     <button class="filter-btn" data-filter="week">Esta Semana</button>
                 </div>
-                
+
+                <div class="history-actions">
+                    <button class="export-btn" onclick="exportOrders()">
+                        <i class="fas fa-file-export"></i> Exportar
+                    </button>
+                    <input type="file" id="import-orders-input" accept="application/json" style="display:none" onchange="importOrders(event)">
+                    <button class="import-btn" onclick="document.getElementById('import-orders-input').click()">
+                        <i class="fas fa-file-import"></i> Importar
+                    </button>
+                </div>
+
                 <div class="historico-lista" id="history-list">
                     <!-- History items will be added here -->
                 </div>

--- a/style.css
+++ b/style.css
@@ -481,6 +481,30 @@
             flex-wrap: wrap;
         }
 
+        .history-actions {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .export-btn, .import-btn {
+            padding: 8px 15px;
+            background: var(--primary);
+            color: white;
+            border: none;
+            border-radius: var(--radius);
+            cursor: pointer;
+            transition: var(--transition);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .export-btn:hover, .import-btn:hover {
+            background: var(--accent);
+        }
+
         .filter-btn {
             padding: 8px 15px;
             background: var(--light-gray);


### PR DESCRIPTION
## Summary
- allow exporting order history as JSON and importing it back
- add UI buttons for import/export
- style the new buttons in CSS

## Testing
- `python -m py_compile app.py laundry_optimizer_final.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853aa2d840883278201023294ecb70b